### PR TITLE
fix: improperly configured exception is ignored

### DIFF
--- a/aldryn_addons/exceptions.py
+++ b/aldryn_addons/exceptions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+
+class ImproperlyConfigured(Exception):
+    """
+    We do not use django.core.exceptions.ImproperlyConfigured, because
+    manage.py will actually silently swallow those, thus not showing us the
+    real error.
+    https://github.com/django/django/blob/1.6.11/django/core/management/__init__.py#L108
+    this is still true up until at least Django 1.9:
+    https://github.com/django/django/blob/3f22e83e90bc2eeea5f65858660385a34fbf5486/django/core/management/__init__.py#L299
+    """
+    pass

--- a/aldryn_addons/settings.py
+++ b/aldryn_addons/settings.py
@@ -7,8 +7,8 @@ import shutil
 import uuid
 from . import utils
 from .utils import global_settings
+from .exceptions import ImproperlyConfigured
 from pprint import pformat
-from django.core.exceptions import ImproperlyConfigured
 
 
 def save_settings_dump(settings, path):


### PR DESCRIPTION
Django swallows ImproperlyConfigured in manage.py, thus causing the user
to never notice if something is wrong with the Addon setup.
Solution: switch to an Exception that does not inherit from djangos'
ImproperlyConfigured. With this change the Exception is always raised
if there is a problem with the configuration.
