### PR TITLE
Add compatibility with Python 3.12

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -62,5 +62,3 @@ jobs:
           python setup.py install
       - name: Run coverage
         run: coverage run setup.py test
-      - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         requirements: ["dj22_cms37", "dj32_cms310", "dj40"]
         exclude:
           - python-version: "3.10"

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -8,15 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Install flake8
         run: pip install --upgrade flake8
       - name: Run flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: flake8
           run: flake8
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - run: python -m pip install isort
       - name: isort
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: isort
           run: isort -c --df aldryn_addons
@@ -50,9 +50,9 @@ jobs:
           - python-version: "3.7"
             requirements: "dj40"
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -63,4 +63,4 @@ jobs:
       - name: Run coverage
         run: coverage run setup.py test
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Aldryn Addons Framework
 =======================
 
-|pypi| |build| |coverage|
+|pypi| |build|
 
 **Aldryn Addons** are re-usable django apps that follow certain conventions to
 abstract out complicated configuration from the individual django website

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -1,6 +1,7 @@
 # other requirements
-# django-app-helper not yet Django 4 compatible
-https://github.com/FinalAngel/django-app-helper/archive/refs/heads/develop.zip#egg=django-app-helper
+packaging
+setuptools
+django-app-helper
 coverage
 isort
 flake8


### PR DESCRIPTION
Python 3.12 removed the `imp` module. This PR replaces it with `importlib`, which is available in all supported Python 3 versions.

Also:
* update all workflow actions,
* test against Python 3.11 and Python 3.12,
* remove CodeCov action (and its badge in the README), since we do not use it anymore anyway

Note that the coverage report is currently lost, we may want to use `actions/upload-artifacts` at some point if we need the data.